### PR TITLE
Use SPDX identifier in license field of META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -6,7 +6,7 @@
   "depends": [
   ],
   "description": "Implements PRECIS framework, rfc7564 and others. Obsoletes stringprep and saslprep",
-  "license": "The Artistic License 2.0",
+  "license": "Artistic-2.0",
   "name": "Unicode::PRECIS",
   "perl": "6.c",
   "provides": {


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license