### PR TITLE
Remove reference to removed uniprop-bool method

### DIFF
--- a/lib/Unicode/PRECIS.pm6
+++ b/lib/Unicode/PRECIS.pm6
@@ -430,7 +430,7 @@ class PRECIS {
   # 9.8.  JoinControl (H)
   method join-control ( Int $codepoint --> Bool ) {
 
-    $codepoint.uniprop-bool('Join_Control');
+    $codepoint.uniprop('Join_Control');
   }
 
   #-----------------------------------------------------------------------------
@@ -467,7 +467,7 @@ class PRECIS {
   # 9.13.  PrecisIgnorableProperties (M)
   method precis-ignorable-properties ( Int $codepoint --> Bool ) {
 
-    $codepoint.uniprop-bool('Default_Ignorable_Code_Point')
+    $codepoint.uniprop('Default_Ignorable_Code_Point')
     or ($codepoint (elem) $Unicode::PRECIS::Tables::NonCharCodepoint::set);
   }
 


### PR DESCRIPTION
The `uniprop-bool` method was undocumented and untested and intended for core developers testing.  Replaced by just a call to `uniprop`, which gives the same result.